### PR TITLE
Only install plugins once

### DIFF
--- a/cloud9_plugins.sh
+++ b/cloud9_plugins.sh
@@ -15,7 +15,12 @@ gem install rufo -v 0.3.1
 fancy_echo "Installing htmlbeautifier gem"
 gem install htmlbeautifier
 fancy_echo "Installing plugins"
-mkdir ~/.c9/plugins
-git clone https://github.com/firstdraft/rubysnippets.git ~/.c9/plugins/rubysnippets
-git clone https://github.com/firstdraft/formathtmlerb.git ~/.c9/plugins/formathtmlerb
-git clone https://github.com/firstdraft/formatruby.git ~/.c9/plugins/formatruby
+if [ ~/.c9/plugins ]
+then
+  fancy_echo "Already installed Cloud 9 plugins"
+else
+  mkdir ~/.c9/plugins
+  git clone https://github.com/firstdraft/rubysnippets.git ~/.c9/plugins/rubysnippets
+  git clone https://github.com/firstdraft/formathtmlerb.git ~/.c9/plugins/formathtmlerb
+  git clone https://github.com/firstdraft/formatruby.git ~/.c9/plugins/formatruby
+fi


### PR DESCRIPTION
Previously there was an issue when re-running this script would throw a not very nice to look at error message:
```
mkdir: cannot create directory '/home/ubuntu/.cfatal: destination path '/home/ubuntu/.c9/plugins/rubysnippets' already exists and is not an empty directory.fatal: destination path '/home/ubuntu/.c9/plugins/formathtmlerb' already exists and is not an empty directory.fatal: destination path '/home/ubuntu/.c9/plugins/formatruby' already exists and is not an empty directory.
== Command ["sh cloud9_plugins.sh"] failed ==
```

This patch fixes that by installing the plugins _only_ if the folder they're installed to is empty.